### PR TITLE
Add poetry and async SQLAlchemy support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "sidequest"
+version = "0.1.0"
+description = "Sidequest task management library"
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.11"
+sqlalchemy = "^2.0"
+aiosqlite = "^0.19"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/sidequest/__init__.py
+++ b/sidequest/__init__.py
@@ -1,16 +1,22 @@
 """Sidequest task management library."""
 
 from .quests import quest, QUEST_REGISTRY
-from .dispatch import dispatch
-from .worker import Worker
-from .queue import InMemoryQueue
-from .db import ResultDB
+from .dispatch import dispatch, adispatch
+from .worker import Worker, AsyncWorker
+from .queue import InMemoryQueue, AsyncInMemoryQueue
+from .db import ResultDB, AsyncResultDB, SQLALCHEMY_AVAILABLE
 
 __all__ = [
     "quest",
     "dispatch",
+    "adispatch",
     "Worker",
+    "AsyncWorker",
     "InMemoryQueue",
+    "AsyncInMemoryQueue",
     "ResultDB",
-    "QUEST_REGISTRY",
 ]
+
+if SQLALCHEMY_AVAILABLE:
+    __all__.append("AsyncResultDB")
+__all__.append("QUEST_REGISTRY")

--- a/sidequest/db.py
+++ b/sidequest/db.py
@@ -4,6 +4,25 @@ import sqlite3
 from typing import Optional, Any
 from datetime import datetime
 
+try:
+    from sqlalchemy import (
+        Column,
+        Integer,
+        MetaData,
+        String,
+        Table,
+        insert,
+        select,
+    )
+    from sqlalchemy.ext.asyncio import (
+        AsyncEngine,
+        AsyncSession,
+        create_async_engine,
+    )
+    SQLALCHEMY_AVAILABLE = True
+except Exception:  # pragma: no cover - sqlalchemy may not be installed
+    SQLALCHEMY_AVAILABLE = False
+
 
 class ResultDB:
     """Database for storing quest results."""
@@ -44,3 +63,59 @@ class ResultDB:
         cur = self.conn.cursor()
         cur.execute("SELECT quest_name, result, error, timestamp FROM results")
         return cur.fetchall()
+
+
+if SQLALCHEMY_AVAILABLE:
+    class AsyncResultDB:
+        """Asynchronous database using SQLAlchemy."""
+
+        def __init__(self, url: str = "sqlite+aiosqlite:///:memory:") -> None:
+            self.engine: AsyncEngine = create_async_engine(url, future=True)
+            self.metadata = MetaData()
+            self.results = Table(
+                "results",
+                self.metadata,
+                Column("id", Integer, primary_key=True, autoincrement=True),
+                Column("quest_name", String),
+                Column("result", String),
+                Column("error", String),
+                Column("timestamp", String),
+            )
+
+            import asyncio
+
+            asyncio.run(self._init_tables())
+
+        async def _init_tables(self) -> None:
+            async with self.engine.begin() as conn:
+                await conn.run_sync(self.metadata.create_all)
+
+        async def store(self, quest_name: str, result: Optional[Any], error: Optional[str]) -> None:
+            async with self.engine.begin() as conn:
+                await conn.execute(
+                    insert(self.results).values(
+                        quest_name=quest_name,
+                        result=None if result is None else str(result),
+                        error=error,
+                        timestamp=datetime.utcnow().isoformat(),
+                    )
+                )
+
+        async def fetch_all(self) -> list[tuple]:
+            async with AsyncSession(self.engine) as session:
+                result = await session.execute(
+                    select(
+                        self.results.c.quest_name,
+                        self.results.c.result,
+                        self.results.c.error,
+                        self.results.c.timestamp,
+                    )
+                )
+                rows = result.all()
+            return [tuple(row) for row in rows]
+else:  # pragma: no cover - used when sqlalchemy is unavailable
+    class AsyncResultDB:  # type: ignore
+        """Placeholder for missing SQLAlchemy dependency."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+            raise ImportError("SQLAlchemy is required for AsyncResultDB")

--- a/sidequest/dispatch.py
+++ b/sidequest/dispatch.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict
 
-from .queue import InMemoryQueue
+from .queue import InMemoryQueue, AsyncInMemoryQueue
 
 
 def dispatch(queue: InMemoryQueue, quest_name: str, *args: Any, **kwargs: Any) -> None:
@@ -13,3 +13,15 @@ def dispatch(queue: InMemoryQueue, quest_name: str, *args: Any, **kwargs: Any) -
         "kwargs": kwargs,
     }
     queue.send(message)
+
+
+async def adispatch(
+    queue: AsyncInMemoryQueue, quest_name: str, *args: Any, **kwargs: Any
+) -> None:
+    """Asynchronously dispatch a quest to the provided queue."""
+    message: Dict[str, Any] = {
+        "quest": quest_name,
+        "args": args,
+        "kwargs": kwargs,
+    }
+    await queue.send(message)

--- a/sidequest/queue.py
+++ b/sidequest/queue.py
@@ -3,6 +3,8 @@
 from queue import Queue
 from typing import Any
 
+import asyncio
+
 
 class InMemoryQueue:
     """A basic in-memory queue using :class:`queue.Queue`."""
@@ -15,6 +17,22 @@ class InMemoryQueue:
 
     def receive(self) -> Any:
         return self._queue.get()
+
+    def empty(self) -> bool:
+        return self._queue.empty()
+
+
+class AsyncInMemoryQueue:
+    """Asynchronous in-memory queue using :class:`asyncio.Queue`."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[Any] = asyncio.Queue()
+
+    async def send(self, message: Any) -> None:
+        await self._queue.put(message)
+
+    async def receive(self) -> Any:
+        return await self._queue.get()
 
     def empty(self) -> bool:
         return self._queue.empty()

--- a/sidequest/worker.py
+++ b/sidequest/worker.py
@@ -3,9 +3,9 @@
 from typing import Any, Dict
 import traceback
 
-from .queue import InMemoryQueue
+from .queue import InMemoryQueue, AsyncInMemoryQueue
 from .quests import QUEST_REGISTRY
-from .db import ResultDB
+from .db import ResultDB, AsyncResultDB
 
 
 class Worker:
@@ -38,3 +38,40 @@ class Worker:
         """Continuously process quests until queue is empty."""
         while not self.queue.empty():
             self.run_once()
+
+
+class AsyncWorker:
+    """Asynchronous worker that consumes quests from a queue."""
+
+    def __init__(self, queue: AsyncInMemoryQueue, db: AsyncResultDB) -> None:
+        self.queue = queue
+        self.db = db
+
+    async def run_once(self) -> None:
+        """Process a single quest if available."""
+        if self.queue.empty():
+            return
+        message: Dict[str, Any] = await self.queue.receive()
+        quest_name: str = message["quest"]
+        args = message.get("args", [])
+        kwargs = message.get("kwargs", {})
+        fn = QUEST_REGISTRY.get(quest_name)
+        if not fn:
+            await self.db.store(quest_name, None, f"Unknown quest: {quest_name}")
+            return
+        try:
+            import inspect
+
+            if inspect.iscoroutinefunction(fn):
+                result = await fn(*args, **kwargs)
+            else:
+                result = fn(*args, **kwargs)
+            await self.db.store(quest_name, result, None)
+        except Exception:  # pylint: disable=broad-except
+            tb = traceback.format_exc()
+            await self.db.store(quest_name, None, tb)
+
+    async def run_forever(self) -> None:
+        """Continuously process quests until queue is empty."""
+        while not self.queue.empty():
+            await self.run_once()

--- a/tests/test_async_sidequest.py
+++ b/tests/test_async_sidequest.py
@@ -1,0 +1,36 @@
+import asyncio
+import unittest
+
+from sidequest import (
+    quest,
+    adispatch,
+    AsyncWorker,
+    AsyncInMemoryQueue,
+    AsyncResultDB,
+)
+
+
+
+@quest
+async def async_add(a, b):
+    await asyncio.sleep(0)
+    return a + b
+
+
+class TestAsyncSidequest(unittest.IsolatedAsyncioTestCase):
+    async def test_async_worker_executes_quest_and_stores_result(self) -> None:
+        queue = AsyncInMemoryQueue()
+        db = AsyncResultDB()
+        await adispatch(queue, "async_add", 1, 2)
+        worker = AsyncWorker(queue, db)
+        await worker.run_forever()
+        results = await db.fetch_all()
+        self.assertEqual(len(results), 1)
+        quest_name, result, error, _ = results[0]
+        self.assertEqual(quest_name, "async_add")
+        self.assertEqual(result, "3")
+        self.assertIsNone(error)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `pyproject.toml` for Poetry
- add async utilities with SQLAlchemy backend
- extend queues, dispatch and worker to support async
- provide async example tests

## Testing
- `python -m unittest tests/test_sidequest.py -v`
- `python -m unittest tests/test_async_sidequest.py -v` *(fails: ImportError: SQLAlchemy is required for AsyncResultDB)*