### PR TITLE
Support quest context return objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@ a SQLite database.
 ```python
 from sidequest import quest, dispatch, Worker, InMemoryQueue, ResultDB
 
-@quest
+QUEUE = InMemoryQueue()
+
+@quest(queue=QUEUE)
 def hello(name):
     return f"Hello {name}!"
 
-queue = InMemoryQueue()
 db = ResultDB()
-
-dispatch(queue, "hello", "World")
-worker = Worker(queue, db)
+hello_ctx = hello("World")
+dispatch(hello_ctx)
+worker = Worker(QUEUE, db)
 worker.run_forever()
 
 print(db.fetch_all())

--- a/sidequest/__init__.py
+++ b/sidequest/__init__.py
@@ -1,6 +1,6 @@
 """Sidequest task management library."""
 
-from .quests import quest, QUEST_REGISTRY
+from .quests import quest, QUEST_REGISTRY, QuestContext
 from .dispatch import dispatch, adispatch
 from .worker import Worker, AsyncWorker
 from .queue import InMemoryQueue, AsyncInMemoryQueue
@@ -15,6 +15,7 @@ __all__ = [
     "InMemoryQueue",
     "AsyncInMemoryQueue",
     "ResultDB",
+    "QuestContext",
 ]
 
 if SQLALCHEMY_AVAILABLE:

--- a/sidequest/dispatch.py
+++ b/sidequest/dispatch.py
@@ -2,11 +2,15 @@
 
 from typing import Any, Dict
 
-from .queue import InMemoryQueue, AsyncInMemoryQueue
+from .quests import QuestContext
 
 
-def dispatch(queue: InMemoryQueue, quest_name: str, *args: Any, **kwargs: Any) -> None:
-    """Dispatch a quest to the provided queue."""
+def dispatch(quest: QuestContext) -> None:
+    """Dispatch a quest using the queue stored in the context."""
+    queue = quest.queue
+    quest_name = quest.quest_name
+    args = quest.args
+    kwargs = quest.kwargs
     message: Dict[str, Any] = {
         "quest": quest_name,
         "args": args,
@@ -15,10 +19,12 @@ def dispatch(queue: InMemoryQueue, quest_name: str, *args: Any, **kwargs: Any) -
     queue.send(message)
 
 
-async def adispatch(
-    queue: AsyncInMemoryQueue, quest_name: str, *args: Any, **kwargs: Any
-) -> None:
-    """Asynchronously dispatch a quest to the provided queue."""
+async def adispatch(quest: QuestContext) -> None:
+    """Asynchronously dispatch a quest using the queue stored in the context."""
+    queue = quest.queue
+    quest_name = quest.quest_name
+    args = quest.args
+    kwargs = quest.kwargs
     message: Dict[str, Any] = {
         "quest": quest_name,
         "args": args,

--- a/tests/test_async_sidequest.py
+++ b/tests/test_async_sidequest.py
@@ -7,22 +7,45 @@ from sidequest import (
     AsyncWorker,
     AsyncInMemoryQueue,
     AsyncResultDB,
+    QuestContext,
 )
+from sidequest.db import SQLALCHEMY_AVAILABLE
 
 
+ASYNC_QUEUE = AsyncInMemoryQueue()
 
-@quest
+
+@quest(queue=ASYNC_QUEUE)
 async def async_add(a, b):
     await asyncio.sleep(0)
     return a + b
 
 
+@unittest.skipUnless(SQLALCHEMY_AVAILABLE, "SQLAlchemy is required for async tests")
 class TestAsyncSidequest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        while not ASYNC_QUEUE.empty():
+            await ASYNC_QUEUE.receive()
+
     async def test_async_worker_executes_quest_and_stores_result(self) -> None:
-        queue = AsyncInMemoryQueue()
         db = AsyncResultDB()
-        await adispatch(queue, "async_add", 1, 2)
-        worker = AsyncWorker(queue, db)
+        ctx = async_add(1, 2)
+        await adispatch(ctx)
+        worker = AsyncWorker(ASYNC_QUEUE, db)
+        await worker.run_forever()
+        results = await db.fetch_all()
+        self.assertEqual(len(results), 1)
+        quest_name, result, error, _ = results[0]
+        self.assertEqual(quest_name, "async_add")
+        self.assertEqual(result, "3")
+        self.assertIsNone(error)
+
+    async def test_async_quest_function_returns_context(self) -> None:
+        db = AsyncResultDB()
+        ctx = async_add(1, 2)
+        self.assertIsInstance(ctx, QuestContext)
+        await adispatch(ctx)
+        worker = AsyncWorker(ASYNC_QUEUE, db)
         await worker.run_forever()
         results = await db.fetch_all()
         self.assertEqual(len(results), 1)

--- a/tests/test_sidequest.py
+++ b/tests/test_sidequest.py
@@ -1,18 +1,46 @@
-from sidequest import quest, dispatch, Worker, InMemoryQueue, ResultDB
+from sidequest import (
+    quest,
+    dispatch,
+    Worker,
+    InMemoryQueue,
+    ResultDB,
+    QuestContext,
+)
 import unittest
 
 
-@quest
+QUEUE = InMemoryQueue()
+
+
+@quest(queue=QUEUE)
 def add(a, b):
     return a + b
 
 
 class TestSidequest(unittest.TestCase):
+    def setUp(self) -> None:
+        while not QUEUE.empty():
+            QUEUE.receive()
+
     def test_worker_executes_quest_and_stores_result(self) -> None:
-        queue = InMemoryQueue()
         db = ResultDB()
-        dispatch(queue, "add", 1, 2)
-        worker = Worker(queue, db)
+        ctx = add(1, 2)
+        dispatch(ctx)
+        worker = Worker(QUEUE, db)
+        worker.run_forever()
+        results = db.fetch_all()
+        self.assertEqual(len(results), 1)
+        quest_name, result, error, _ = results[0]
+        self.assertEqual(quest_name, "add")
+        self.assertEqual(result, "3")
+        self.assertIsNone(error)
+
+    def test_quest_function_returns_context(self) -> None:
+        db = ResultDB()
+        ctx = add(1, 2)
+        self.assertIsInstance(ctx, QuestContext)
+        dispatch(ctx)
+        worker = Worker(QUEUE, db)
         worker.run_forever()
         results = db.fetch_all()
         self.assertEqual(len(results), 1)


### PR DESCRIPTION
## Summary
- allow quest decorator to bind a queue
- quest functions now return a QuestContext including the queue
- dispatch/adispatch take a QuestContext
- update README example
- update tests to new API

## Testing
- `python -m unittest discover -s tests`