### PR TITLE
Use Poetry in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Set up Poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: 1.6.1
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+      - name: Run tests
+        run: poetry run pytest -q


### PR DESCRIPTION
## Summary
- use Poetry to install dependencies in the workflow
- run tests through Poetry

## Testing
- `poetry install -vvv --no-interaction --no-root` *(fails: cannot connect to pypi.org)*
- `poetry run pytest -q` *(fails: Command not found: pytest)*
