### PR TITLE
Add DB teardown between tests

### DIFF
--- a/sidequest/db.py
+++ b/sidequest/db.py
@@ -69,3 +69,9 @@ class ResultDB:
             )
             rows = result.all()
         return [tuple(row) for row in rows]
+
+    async def teardown(self) -> None:
+        """Drop all tables and dispose of the engine."""
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await self.engine.dispose()

--- a/tests/test_sidequest.py
+++ b/tests/test_sidequest.py
@@ -27,6 +27,9 @@ class TestSidequest(unittest.IsolatedAsyncioTestCase):
         self.db = ResultDB()
         await self.db.setup()
 
+    async def asyncTearDown(self) -> None:
+        await self.db.teardown()
+
     async def test_async_worker_executes_quest_and_stores_result(self) -> None:
         ctx = async_add(1, 2)
         await dispatch(ctx)


### PR DESCRIPTION
## Summary
- drop tables and dispose DB connection via `ResultDB.teardown`
- ensure test suite tears down the DB between tests

## Testing
- `python -m unittest -v` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*