### PR TITLE
Add GitHub action for tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,24 @@
+name: Run tests
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install Poetry
+        run: |
+          pip install poetry
+      - name: Install dependencies
+        run: |
+          poetry install --no-interaction --no-root
+      - name: Run tests
+        run: |
+          poetry run pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs `poetry run pytest` on pull requests

## Testing
- `poetry install --no-interaction --no-root -vvv` *(fails: All attempts to connect to pypi.org failed)*
- `poetry run pytest -q` *(fails: Command not found: pytest)*