### PR TITLE
Fix GitHub test workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,24 @@
+name: Run tests
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install Poetry
+        run: |
+          pip install poetry
+      - name: Install dependencies
+        run: |
+          poetry install --no-interaction
+      - name: Run tests
+        run: |
+          poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -281,4 +281,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "555a31c4e45b30eb152610c375568178def7ea2db4f0190ccf3cde52cacc3963"
+content-hash = "97e171ea49fef8bb24bf305042c4943d387f9c156415ccdaf7929c9474c41ff6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ sqlalchemy = "^2.0"
 aiosqlite = "^0.21"
 greenlet = "^3.2.2"
 
-[tool.poetry.dev-dependencies]
+
+[tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"
 pytest-asyncio = "^0.26.0"
 


### PR DESCRIPTION
## Summary
- install dev dependencies in pyproject via new group syntax
- ensure GitHub workflow installs the root package before running tests

## Testing
- `poetry lock` *(fails: All attempts to connect to pypi.org failed)*
- `python tests/test_sidequest.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*