### PR TITLE
Add pyright linting

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install --no-interaction
+      - name: Run pyright
+        run: |
+          poetry run pyright
       - name: Run tests
         run: |
           poetry run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ greenlet = "^3.2.2"
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"
 pytest-asyncio = "^0.26.0"
+pyright = "^1.1.350"
 
 
 [build-system]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+    "include": ["sidequest", "tests"]
+}


### PR DESCRIPTION
## Summary
- install pyright as a dev dependency
- add a basic `pyrightconfig.json`
- run pyright in CI before tests

## Testing
- `pyright`
- `python -m pytest -q` *(fails: No module named pytest)*