### PR TITLE
Fix capitalization for SideQuest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Sidequest
+# SideQuest
 
-Sidequest is a simple task management library. Tasks, known as *quests*, are
+SideQuest is a simple task management library. Tasks, known as *quests*, are
 registered with the `@quest` decorator. Quests can be dispatched to a message
 queue and later executed by a worker. Results of quest executions are stored in
 a SQLite database.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "sidequest"
 version = "0.1.0"
-description = "Sidequest task management library"
+description = "SideQuest task management library"
 authors = []
 
 [tool.poetry.dependencies]

--- a/sidequest/__init__.py
+++ b/sidequest/__init__.py
@@ -1,4 +1,4 @@
-"""Sidequest task management library."""
+"""SideQuest task management library."""
 
 from .quests import quest, QUEST_REGISTRY, QuestContext, ResultRef
 from .dispatch import dispatch

--- a/tests/test_sidequest.py
+++ b/tests/test_sidequest.py
@@ -37,7 +37,7 @@ async def model_manip(a: int, b: _TestModel) -> _TestModel:
     )
 
 
-class TestSidequest(unittest.IsolatedAsyncioTestCase):
+class TestSideQuest(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         while not QUEUE.empty():
             await QUEUE.receive()


### PR DESCRIPTION
## Summary
- standardize project name to "SideQuest"

## Testing
- `pytest -q` *(fails: command not found)*