### PR TITLE
Apply suggested improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ async def hello(name):
 
 async def main() -> None:
     db = ResultDB()
+    await db.setup()
     hello_ctx = hello("World")
     await dispatch(hello_ctx)
     worker = Worker(QUEUE, db)

--- a/sidequest/__init__.py
+++ b/sidequest/__init__.py
@@ -1,6 +1,6 @@
 """SideQuest task management library."""
 
-from .quests import quest, QUEST_REGISTRY, QuestContext, ResultRef
+from .quests import quest, QUEST_REGISTRY, QuestContext
 from .dispatch import dispatch
 from .worker import Worker
 from .queue import InMemoryQueue
@@ -12,7 +12,6 @@ __all__ = [
     "Worker",
     "InMemoryQueue",
     "QuestContext",
-    "ResultRef",
     "ResultDB",
     "QUEST_REGISTRY",
 ]

--- a/sidequest/db.py
+++ b/sidequest/db.py
@@ -1,6 +1,6 @@
 """Simple SQLite-based result storage."""
 
-from typing import Optional, Any, get_type_hints
+from typing import Optional, Any
 from datetime import datetime
 
 from sqlalchemy import String, select
@@ -116,10 +116,7 @@ class ResultDB:
             fn = QUEST_REGISTRY.get(quest_name)
             result_type = Any
             if fn is not None:
-                try:
-                    result_type = get_type_hints(fn).get("return", Any)
-                except Exception:  # pragma: no cover
-                    result_type = Any
+                result_type = fn.return_type
             return TypeAdapter(result_type).validate_json(value)
 
     async def teardown(self) -> None:

--- a/sidequest/quests.py
+++ b/sidequest/quests.py
@@ -7,7 +7,6 @@ from typing import (
     Callable,
     Dict,
     Tuple,
-    Optional,
     TypeVar,
     ParamSpec,
     Generic,
@@ -27,14 +26,6 @@ P_params = ParamSpec("P_params")
 QuestImplementation: TypeAlias = Callable[P_params, Awaitable[T_result]]
 
 QUEST_REGISTRY: Dict[str, "QuestWrapper"] = {}
-
-
-@dataclass
-class ResultRef(Generic[T_result]):
-    """Reference to the result of another quest."""
-
-    context_id: str
-    context: Optional["QuestContext[T_result]"] = None
 
 
 @dataclass
@@ -63,7 +54,7 @@ class QuestWrapper(Generic[P_params, T_result]):
     _queue: InMemoryQueue
     _signature: Signature
 
-    def __call__(self, *args: P_params.args, **kwargs: P_params.kwargs) -> QuestContext:
+    def __call__(self, *args: P_params.args, **kwargs: P_params.kwargs) -> QuestContext[T_result]:
         """Invoke the quest with the given arguments."""
         return QuestContext(self._func.__name__, self._queue, args, kwargs)
 

--- a/tests/test_sidequest.py
+++ b/tests/test_sidequest.py
@@ -51,7 +51,11 @@ class TestSideQuest(unittest.IsolatedAsyncioTestCase):
         ctx = add(1, 2)
         await dispatch(ctx)
         worker = Worker(QUEUE, self.db)
-        await worker.run_forever()
+        task = asyncio.create_task(worker.run_forever())
+        while not QUEUE.empty():
+            await asyncio.sleep(0)
+        worker.stop()
+        await task
         results = await self.db.fetch_all()
         self.assertEqual(len(results), 1)
         _, quest_name, result, error, _ = results[0]
@@ -64,7 +68,11 @@ class TestSideQuest(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(ctx, QuestContext)
         await dispatch(ctx)
         worker = Worker(QUEUE, self.db)
-        await worker.run_forever()
+        task = asyncio.create_task(worker.run_forever())
+        while not QUEUE.empty():
+            await asyncio.sleep(0)
+        worker.stop()
+        await task
         results = await self.db.fetch_all()
         self.assertEqual(len(results), 1)
         _, quest_name, result, error, _ = results[0]
@@ -78,7 +86,11 @@ class TestSideQuest(unittest.IsolatedAsyncioTestCase):
         ctx3 = add(ctx1.cast, ctx2.cast)
         await dispatch(ctx3)
         worker = Worker(QUEUE, self.db)
-        await worker.run_forever()
+        task = asyncio.create_task(worker.run_forever())
+        while not QUEUE.empty():
+            await asyncio.sleep(0)
+        worker.stop()
+        await task
         results = await self.db.fetch_all()
         self.assertEqual(len(results), 3)
         result = await self.db.fetch_result(ctx3.id)
@@ -88,7 +100,11 @@ class TestSideQuest(unittest.IsolatedAsyncioTestCase):
         ctx = model_manip(1, _TestModel(name="test", value=2))
         await dispatch(ctx)
         worker = Worker(QUEUE, self.db)
-        await worker.run_forever()
+        task = asyncio.create_task(worker.run_forever())
+        while not QUEUE.empty():
+            await asyncio.sleep(0)
+        worker.stop()
+        await task
         results = await self.db.fetch_all()
         self.assertEqual(len(results), 1)
         _, quest_name, result, error, _ = results[0]


### PR DESCRIPTION
## Summary
- call `ResultDB.setup` in README example
- simplify type handling in `fetch_result`
- remove unused `ResultRef`
- make `QuestWrapper.__call__` preserve generic result type
- add stop semantics to `Worker.run_forever`
- update tests for new worker behavior

## Testing
- `ruff check .`
- `pyright` *(fails: Import "sqlalchemy" could not be resolved)*
- `python -m pytest -q` *(fails: No module named pytest)*