### PR TITLE
Add BaseWorker abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ class HeartbeatWorker(Worker):
         # emit heartbeat here
         return await super().execute_quest(quest, args, kwargs)
 
+```
 
 ### Chaining quests
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ from sidequest import (
     quest,
     dispatch,
     Worker,
+    BaseWorker,
     InMemoryQueue,
     ResultDB,
 )
@@ -34,4 +35,20 @@ async def main() -> None:
 
 
 asyncio.run(main())
+```
+
+## Custom workers
+
+`Worker` is built on top of the :class:`BaseWorker` class. You can subclass
+`BaseWorker` to implement custom behaviour. For example, a worker that sends
+heartbeat signals for long running quests might override :meth:`handle_message`
+or :meth:`execute_quest`.
+
+```python
+from sidequest import Worker
+
+class HeartbeatWorker(Worker):
+    async def execute_quest(self, quest, args, kwargs):
+        # emit heartbeat here
+        return await super().execute_quest(quest, args, kwargs)
 ```

--- a/sidequest/__init__.py
+++ b/sidequest/__init__.py
@@ -2,7 +2,7 @@
 
 from .quests import quest, QUEST_REGISTRY, QuestContext
 from .dispatch import dispatch
-from .worker import Worker
+from .worker import Worker, BaseWorker
 from .queue import InMemoryQueue
 from .db import ResultDB
 
@@ -10,6 +10,7 @@ __all__ = [
     "quest",
     "dispatch",
     "Worker",
+    "BaseWorker",
     "InMemoryQueue",
     "QuestContext",
     "ResultDB",

--- a/sidequest/worker.py
+++ b/sidequest/worker.py
@@ -1,16 +1,19 @@
-"""Worker implementation to execute quests from a queue."""
+"""Worker implementations to execute quests from a queue."""
+
+from __future__ import annotations
 
 from typing import Any, Dict
+from abc import ABC, abstractmethod
 import asyncio
 import traceback
 
 from .queue import InMemoryQueue
-from .quests import QUEST_REGISTRY
+from .quests import QUEST_REGISTRY, QuestWrapper
 from .db import ResultDB
 
 
-class Worker:
-    """Asynchronous worker that consumes quests from a queue."""
+class BaseWorker(ABC):
+    """Base class for workers that consume quests from a queue."""
 
     def __init__(self, queue: InMemoryQueue, db: ResultDB) -> None:
         self.queue = queue
@@ -26,6 +29,38 @@ class Worker:
         if self.queue.empty():
             return
         message: Dict[str, Any] = await self.queue.receive()
+        await self.handle_message(message)
+
+    async def run_forever(self) -> None:
+        """Continuously process quests until :meth:`stop` is called."""
+        while not self._stop:
+            await self.run_once()
+            if self.queue.empty():
+                await self.on_idle()
+
+    async def on_idle(self) -> None:
+        """Hook invoked when the worker has no quests to process."""
+        await asyncio.sleep(0)
+
+    @abstractmethod
+    async def handle_message(self, message: Dict[str, Any]) -> None:
+        """Handle a single quest message."""
+
+
+class Worker(BaseWorker):
+    """Default worker implementation that executes quests sequentially."""
+
+    async def execute_quest(
+        self,
+        quest: QuestWrapper[Any, Any],
+        args: Any,
+        kwargs: Any,
+    ) -> Any:
+        """Execute the quest function. Subclasses may override."""
+
+        return await quest.accept(*args, **kwargs)
+
+    async def handle_message(self, message: Dict[str, Any]) -> None:
         quest_name: str = message["quest"]
         context_id: str = message["id"]
         args = message.get("args", [])
@@ -51,15 +86,9 @@ class Worker:
 
             args = await resolve(args)
             kwargs = await resolve(kwargs)
-            result = await fn.accept(*args, **kwargs)
+            result = await self.execute_quest(fn, args, kwargs)
             await self.db.store(context_id, quest_name, result, None)
         except Exception:  # pylint: disable=broad-except
             tb = traceback.format_exc()
             await self.db.store(context_id, quest_name, None, tb)
 
-    async def run_forever(self) -> None:
-        """Continuously process quests until :meth:`stop` is called."""
-        while not self._stop:
-            await self.run_once()
-            if self.queue.empty():
-                await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
- add `BaseWorker` abstract class
- update `Worker` to subclass `BaseWorker`
- document custom worker usage

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*