### PR TITLE
Add workflow status tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,11 @@ async def run_workflow() -> None:
     db = ResultDB()
     await db.setup()
     wf = Workflow(multiply(add(1, 2).cast, add(3, 4).cast))
-    await wf.dispatch()
+    await wf.dispatch(db)
     worker = Worker(QUEUE, db)
     await worker.run_forever()
     print(await wf.result(db))
+    print(await wf.status(db))
 
 asyncio.run(run_workflow())
 ```

--- a/sidequest/__init__.py
+++ b/sidequest/__init__.py
@@ -4,7 +4,7 @@ from .quests import quest, QUEST_REGISTRY, QuestContext
 from .dispatch import dispatch
 from .worker import Worker, BaseWorker
 from .queue import InMemoryQueue
-from .db import ResultDB
+from .db import ResultDB, QuestStatus
 from .workflow import Workflow
 
 __all__ = [
@@ -16,5 +16,6 @@ __all__ = [
     "QuestContext",
     "Workflow",
     "ResultDB",
+    "QuestStatus",
     "QUEST_REGISTRY",
 ]


### PR DESCRIPTION
## Summary
- track quest status in DB
- expose QuestStatus and new workflow helpers
- adjust worker to update status
- update README and tests accordingly

## Testing
- `ruff check .`
- `pyright`
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*