### PR TITLE
Enable concurrent workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+Multiple workers can consume from the same queue concurrently:
+
+```python
+worker1 = Worker(QUEUE, db)
+worker2 = Worker(QUEUE, db)
+await asyncio.gather(worker1.run_forever(), worker2.run_forever())
+```
+
 ## Custom workers
 
 `Worker` is built on top of the :class:`BaseWorker` class. You can subclass

--- a/sidequest/db.py
+++ b/sidequest/db.py
@@ -119,6 +119,15 @@ class ResultDB:
                 result_type = fn.return_type
             return TypeAdapter(result_type).validate_json(value)
 
+    async def exists(self, context_id: str) -> bool:
+        """Return ``True`` if a result entry with the given context id exists."""
+        async with self.session_factory() as session:
+            result = await session.execute(
+                select(Result.id).where(Result.context_id == context_id)
+            )
+            row = result.first()
+            return row is not None
+
     async def teardown(self) -> None:
         """Drop all tables and dispose of the engine."""
         async with self.engine.begin() as conn:


### PR DESCRIPTION
## Summary
- let dispatch messages declare dependencies
- requeue tasks if dependencies aren't complete
- expose ResultDB.exists for dependency checks
- allow multiple workers on the same queue
- add docs and tests for multiple workers

## Testing
- `ruff check .`
- `pyright` *(fails: Import errors for missing optional dependencies)*
- `python -m pytest -q` *(fails: No module named pytest)*