### PR TITLE
Add workflow status API

### DIFF
--- a/sidequest/workflow.py
+++ b/sidequest/workflow.py
@@ -44,10 +44,29 @@ class Workflow(Generic[T_result]):
         """Return all quest contexts in the workflow."""
         return _collect_contexts(self.root, set())
 
-    async def dispatch(self) -> None:
+    async def dispatch(self, db: ResultDB | None = None) -> None:
         """Dispatch all quests in the workflow."""
-        await dispatch(self.root)
+        await dispatch(self.root, db)
 
     async def result(self, db: ResultDB) -> T_result | None:
         """Fetch the result of the root quest from the database."""
         return await db.fetch_result(self.root.id)
+
+    async def statuses(self, db: ResultDB) -> List[tuple[str, str, str]]:
+        """Return ``(id, quest_name, status)`` for all quests in the workflow."""
+        states: List[tuple[str, str, str]] = []
+        for ctx in self.contexts():
+            record = await db.fetch_record(ctx.id)
+            if record is None:
+                continue
+            quest_name, status, _err, deps = record
+            if status == "PENDING":
+                waiting = False
+                for dep in deps:
+                    dep_status = await db.fetch_status(dep)
+                    if dep_status not in ("SUCCESS", "FAILED"):
+                        waiting = True
+                        break
+                status = "WAITING" if waiting else "PENDING"
+            states.append((ctx.id, quest_name, status))
+        return states


### PR DESCRIPTION
## Summary
- extend Result model to store quest status and dependencies
- insert tasks when dispatching workflows
- track task status transitions in the worker
- expose `Workflow.statuses` helper and add tests for status monitoring

## Testing
- `poetry run ruff check .`
- `poetry run pyright` *(fails: Import "sqlalchemy" could not be resolved)*
- `python -m pytest -q` *(fails: No module named pytest)*